### PR TITLE
render UI elements even without root to reduce UI thrashing

### DIFF
--- a/app/src/components/DraftView.tsx
+++ b/app/src/components/DraftView.tsx
@@ -21,7 +21,7 @@ let documents = Documents()
 type DraftViewProps = {
   id: string
   did: string
-  root: Layer
+  root?: Layer
   author: Author
 }
 
@@ -33,7 +33,7 @@ export default function DraftView(props: DraftViewProps) {
   let [, setLocation] = useLocation()
   let [authorColors, setAuthorColors] = useState<AuthorColorsType>({})
   let [sync_state, setSyncState] = useState<SYNC_STATE>(SYNC_STATE.SYNCED)
-  let [rootId, setRoot] = useState<string>(root.id)
+  let [rootId, setRoot] = useState<string>(root?.id || '')
   let [reviewMode, setReviewMode] = useState<boolean>(false)
   let [layers, setLayers] = useState<Layer[]>([])
   let [history, setHistory] = useState<Layer[]>([])
@@ -274,13 +274,13 @@ export default function DraftView(props: DraftViewProps) {
                   `}
                 >
                   <Button
-                    disabled={rootId !== layer.parent_id}
+                    disabled={!rootId || rootId !== layer.parent_id}
                     onClick={handleMergeClick}
                   >
                     Merge to document
                   </Button>
                   <Button
-                    disabled={rootId === layer.parent_id}
+                    disabled={!rootId || rootId === layer.parent_id}
                     onClick={handleUpdateClick}
                   >
                     Update from current

--- a/app/src/components/EditReview.tsx
+++ b/app/src/components/EditReview.tsx
@@ -11,7 +11,7 @@ import { EditorView } from './Editor'
 
 type Props = {
   id: string
-  root: Layer
+  root?: Layer
   visible: Layer[]
   onChange: any
   author: Author
@@ -21,11 +21,6 @@ type Props = {
 
 export function EditReviewView(props: Props) {
   const { root, visible, onChange, reviewMode, colors } = props
-  console.log('rendering EditReviewView')
-  if (!root) {
-    console.log('no root')
-    return <div></div>
-  }
 
   // visible.length === 0 or visible.length > 1
   let reviewView = (

--- a/app/src/components/Review.tsx
+++ b/app/src/components/Review.tsx
@@ -16,7 +16,7 @@ type ReviewState = {
 }
 
 export function ReviewView(props: {
-  root: Layer
+  root?: Layer
   visible: Layer[]
   colors?: AuthorColorsType
 }) {
@@ -24,6 +24,8 @@ export function ReviewView(props: {
 
   let updateAtjsonState = useCallback(
     async function () {
+      if (!root) return
+
       if (!visible.length) {
         let atjsonLayer = new UpwellSource({
           content: '',

--- a/app/src/components/withDocument.tsx
+++ b/app/src/components/withDocument.tsx
@@ -54,7 +54,6 @@ export default function withDocument(
       }
     }, [id, author, setLocation])
 
-    if (!root) return <div>Loading..</div>
     return <WrappedComponent root={root} {...props} />
   }
 }


### PR DESCRIPTION
There's probably some bugs I haven't found yet but this seems serviceable for now: 

https://user-images.githubusercontent.com/1589186/158715763-971cf467-86be-4c59-a853-453268cbbbe2.mov

