### PR TITLE
more info for untitled draft placeholder, and draft name suggestion

### DIFF
--- a/app/src/components/DraftView.tsx
+++ b/app/src/components/DraftView.tsx
@@ -15,7 +15,7 @@ import debug from 'debug'
 import Select, { DetailedOption } from './Select'
 import { ReactComponent as Pancake } from '../components/icons/Pancake.svg'
 import { ReactComponent as Pancakes } from '../components/icons/Pancakes.svg'
-import { getYourDrafts } from '../util'
+import { getTempDraftName, getYourDrafts } from '../util'
 import InputModal from './InputModal'
 import DraftMenu from './DraftMenu'
 import { useLocation } from 'wouter'
@@ -245,7 +245,10 @@ export default function DraftView(props: DraftViewProps) {
     if (draftMeta.id === upwell.rootDraft.id) return '(not in a draft)'
     let draftInstance = upwell.get(draftMeta.id)
     return draftInstance.message.startsWith(Upwell.SPECIAL_UNNAMED_SLUG)
-      ? 'Untitled'
+      ? getTempDraftName({
+          date: new Date(draftInstance.created_at),
+          author: author.name,
+        })
       : draftInstance.message
   }
 
@@ -275,11 +278,13 @@ export default function DraftView(props: DraftViewProps) {
     >
       <InputModal
         open={modalState === ModalState.MERGE}
+        author={author.name}
         onSubmit={onMerge}
         onClose={handleModalClose}
       />
       <InputModal
         open={modalState === ModalState.NEW_DRAFT}
+        author={author.name}
         onSubmit={createDraft}
         onClose={handleModalClose}
       />

--- a/app/src/components/InputModal.tsx
+++ b/app/src/components/InputModal.tsx
@@ -6,20 +6,23 @@ import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import { useState } from 'react'
 import { Button } from './Button'
+import { getTempDraftName } from '../util'
 
 type InputModalProps = {
   onSubmit?: Function
   open: boolean
   onClose: Function
   title?: string
+  author?: string
 }
 export default function InputModal({
   onSubmit,
   open,
   onClose,
   title = 'Name your changes',
+  author = '',
 }: InputModalProps) {
-  const [text, setText] = useState('')
+  const [text, setText] = useState(getTempDraftName({ author }))
 
   const handleClose = () => {
     onClose()
@@ -47,6 +50,7 @@ export default function InputModal({
             type="text"
             fullWidth
             variant="standard"
+            value={text}
             onChange={(e) => setText(e.target.value)}
           />
         </DialogContent>

--- a/app/src/util.ts
+++ b/app/src/util.ts
@@ -27,3 +27,13 @@ export function getYourDrafts(
 export function getAuthorHighlight(hexColor: string): string {
   return hexColor + '40'
 }
+
+type TempDraftName = {
+  date?: Date
+  author?: string
+}
+export function getTempDraftName({ date = new Date(), author }: TempDraftName) {
+  return (
+    (author ? `${author}'s ` : '') + `draft on ` + date.toLocaleDateString()
+  )
+}


### PR DESCRIPTION
"Untitled" as a placeholder name for an unnamed draft is confusing. This proposes two places where untitled drafts get a more information-heavy placeholder: 
1) Drafts automatically created by trying to edit the Stack get a placeholder name in the format of "user's draft on 03/12/2022"
2) When creating a new draft, a name is suggested in that same format (instead of an empty input)

https://user-images.githubusercontent.com/1589186/165119786-0c9360af-6c80-4960-850e-b8cbd9d2fcf7.mov

