### PR TITLE
remove author color from change bars, fix scroll

### DIFF
--- a/app/src/components/Editor.tsx
+++ b/app/src/components/Editor.tsx
@@ -250,6 +250,7 @@ export function Editor(props: Props) {
         ${textCSS}
         caret-color: ${color || 'auto'};
         overflow-wrap: break-word;
+        position: relative; /* for change bars */
       `}
     />
   )

--- a/app/src/prosemirror/AutomergeChangesPlugin.ts
+++ b/app/src/prosemirror/AutomergeChangesPlugin.ts
@@ -31,7 +31,6 @@ function changeSetToMarginDecorations(changeSet: ChangeSet, draft: Draft) {
       sidebarThing.style.position = 'absolute'
       let fromCoords = view.coordsAtPos(from)
       let toCoords = view.coordsAtPos(to)
-      sidebarThing.style.top = `${fromCoords.top}px`
       sidebarThing.style.height = `${toCoords.bottom - fromCoords.top}px`
       sidebarThing.style.left = `${
         view.dom.clientLeft +
@@ -40,13 +39,16 @@ function changeSetToMarginDecorations(changeSet: ChangeSet, draft: Draft) {
             .getComputedStyle(view.dom, null)
             .getPropertyValue('padding-left')
         ) -
-        5
+        12
       }px`
       sidebarThing.style.width = '3px'
       sidebarThing.style.borderRadius = '3px'
-      sidebarThing.style.background = documents.upwell!.getAuthorColor(
-        change.actor.slice(0, 32)
-      )
+      // keeping this around because it's cool. You can show the change heatmap with author colors:
+      // sidebarThing.style.background = documents.upwell!.getAuthorColor(
+      // change.actor.slice(0, 32)
+      // )
+      sidebarThing.style.background = '#0000003E'
+      sidebarThing.title = 'changes'
       return sidebarThing
     })
   })


### PR DESCRIPTION
As per the designs, the history comparison view left side change bars should not contain author colours. Also fixed a big where the change bars didn't scroll with the text. 

I made the bars slightly transparent, which allows the edit density to show through: 

![Screen Shot](https://user-images.githubusercontent.com/1589186/165920970-22eaba6f-b41d-44de-916c-e5f2321504dc.jpg)
